### PR TITLE
Add custom linker scripts support

### DIFF
--- a/utils.cmake
+++ b/utils.cmake
@@ -34,3 +34,8 @@ function(generate_object target suffix type)
         "${CMAKE_CURRENT_BINARY_DIR}/${target}${CMAKE_EXECUTABLE_SUFFIX}" "${CMAKE_CURRENT_BINARY_DIR}/${target}${suffix}"
     )
 endfunction()
+
+# Add custom linker script to the linker flags
+function(linker_script_add path_to_script)
+    string(APPEND CMAKE_EXE_LINKER_FLAGS " -T ${path_to_script}")
+endfunction()

--- a/utils.cmake
+++ b/utils.cmake
@@ -39,3 +39,11 @@ endfunction()
 function(linker_script_add path_to_script)
     string(APPEND CMAKE_EXE_LINKER_FLAGS " -T ${path_to_script}")
 endfunction()
+
+# Update a target LINK_DEPENDS property with a custom linker script.
+# That allows to rebuild that target if the linker script gets changed
+function(linker_script_target_dependency target path_to_script)
+    get_target_property(_cur_link_deps ${target} LINK_DEPENDS)
+    string(APPEND _cur_link_deps " ${path_to_script}")
+    set_target_properties(${target} PROPERTIES LINK_DEPENDS ${_cur_link_deps})
+endfunction()


### PR DESCRIPTION
As of the requiest in #1 the support for custom linker scripts required in `utils.cmake`. In this PR several functions are introduced:
- `linker_script_add` - allows to append a linker script to linker command's arguments
- `linker_script_target_dependency` - allows to add target's dependency on a linker script in order to track any changes are made and rebuild the target in case of changes