### PR TITLE
Fix cross-compiler detection

### DIFF
--- a/arm-gcc-toolchain.cmake
+++ b/arm-gcc-toolchain.cmake
@@ -17,7 +17,7 @@ execute_process(
 
 get_filename_component(ARM_TOOLCHAIN_DIR ${BINUTILS_PATH} DIRECTORY)
 # Without that flag CMake is not able to pass test compilation check
-set(CMAKE_EXE_LINKER_FLAGS_INIT "--specs=nosys.specs")
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 
 set(CMAKE_C_COMPILER ${TOOLCHAIN_PREFIX}gcc)
 set(CMAKE_ASM_COMPILER ${CMAKE_C_COMPILER})

--- a/clang-arm-gcc-toolchain.cmake
+++ b/clang-arm-gcc-toolchain.cmake
@@ -27,7 +27,7 @@ set(CMAKE_CXX_COMPILER_TARGET ${triple})
 set(CMAKE_C_FLAGS_INIT "-B${ARM_TOOLCHAIN_DIR}")
 set(CMAKE_CXX_FLAGS_INIT "-B${ARM_TOOLCHAIN_DIR}")
 # only for successful compilation of CMake test
-set(CMAKE_EXE_LINKER_FLAGS_INIT "--specs=nosys.specs")
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 # provide clang with ARM GCC toolchain include directory info
 include_directories(${ARM_TOOLCHAIN_DIR}/../${TOOLCHAIN_TRIPLE}/include)
 


### PR DESCRIPTION
Set CMAKE_TRY_COMPILE_TARGET_TYPE to STATIC_LIBRARY to fix CMake's compiler
check. This feature requires CMake 3.6 or newer.