### PR TITLE
feature/issue-6-Add_support_for_ARM_GCC_builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ dist: xenial
 matrix:
   include:
     - os: linux
+      name: "ARM GCC"
       env:
         - "C_COMPILER=arm-none-eabi-gcc"
         - "CXX_COMPILER=arm-none-eabi-gcc"
@@ -14,6 +15,7 @@ matrix:
         - "LLD=arm-none-eabi-ld.bfd"
 
     - os: linux
+      name: "Clang 6.0"
       env:
         - "C_COMPILER=clang-6.0"
         - "CXX_COMPILER=clang++-6.0"
@@ -31,6 +33,7 @@ matrix:
             - lld-6.0
 
     - os: linux
+      name: "Clang 7.0"
       env:
         - "C_COMPILER=clang-7"
         - "CXX_COMPILER=clang++-7"
@@ -48,6 +51,7 @@ matrix:
             - lld-7
 
     - os: linux
+      name: "Clang 8.0"
       env:
         - "C_COMPILER=clang-8"
         - "CXX_COMPILER=clang++-8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: c
 dist: xenial
 
 matrix:
+  fast_finish: true
   include:
     - os: linux
       name: "ARM GCC"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,15 @@ matrix:
   include:
     - os: linux
       env:
+        - "C_COMPILER=arm-none-eabi-gcc"
+        - "CXX_COMPILER=arm-none-eabi-gcc"
+        - "SIZE=arm-none-eabi-size"
+        - "OBJCOPY=arm-none-eabi-objcopy"
+        - "LINKER=arm-none-eabi-ld"
+        - "LLD=arm-none-eabi-ld.bfd"
+
+    - os: linux
+      env:
         - "C_COMPILER=clang-6.0"
         - "CXX_COMPILER=clang++-6.0"
         - "SIZE=llvm-size-6.0"

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-if [ ! -z "${TRAVIS+set}" ]; then
+set_clang() {
     # Make package installation path preceed Travis installed packages in /usr/local/bin
     export PATH=/usr/bin:$PATH
     sudo update-alternatives --install /usr/bin/clang clang /usr/bin/${C_COMPILER} 1000 --slave /usr/bin/clang++ clang++ /usr/bin/${CXX_COMPILER}
@@ -16,6 +16,20 @@ if [ ! -z "${TRAVIS+set}" ]; then
     # LLVM objcopy version 7 misses `--version` support
     llvm-objcopy -version || true
     ld.lld --version
+}
+
+if [ ! -z "${TRAVIS+set}" ]; then
+    case "${C_COMPILER}" in
+    *clang*)
+        set_clang
+        ;;
+    *gcc*)
+        echo GCC
+        ;;
+    *)
+        exit 1
+        ;;
+esac
 fi
 
 # Download ARM GCC toolchain from the official site
@@ -35,5 +49,10 @@ cd examples/efm32/led
 mkdir -p build-clang
 cd build-clang
 
-cmake .. -DCMAKE_TOOLCHAIN_FILE=${PROJECT_ROOT}/clang-arm-gcc-toolchain.cmake
+if [ "${C_COMPILER}" != "${C_COMPILER%*clang*}" ]; then
+    cmake .. -DCMAKE_TOOLCHAIN_FILE=${PROJECT_ROOT}/clang-arm-gcc-toolchain.cmake
+else
+    cmake .. -DCMAKE_TOOLCHAIN_FILE=${PROJECT_ROOT}/arm-gcc-toolchain.cmake
+fi
+
 cmake --build .

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -24,7 +24,7 @@ if [ ! -z "${TRAVIS+set}" ]; then
         set_clang
         ;;
     *gcc*)
-        echo GCC
+        # Do nothing here at that point
         ;;
     *)
         exit 1


### PR DESCRIPTION
Add support for ARM GCC builds in `.travis.yml`:
 
 - extend `ci/scripts.sh` to support Clang/ARM GCC selection
 - update Matrix builds' names