### PR TITLE
Add support for Mac OSX builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,8 @@ matrix:
     # Clang/LLVM (macOS)
 
     - os: osx
-      name: "Mac OSX XCode latest"
+      osx_image: xcode10.1
+      name: "Mac OSX LLVM 7"
       env:
         - "C_COMPILER=clang"
         - "CXX_COMPILER=clang++"
@@ -85,10 +86,16 @@ matrix:
         - "OBJCOPY=llvm-objcopy"
         - "LINKER=lld"
         - "LLD=ld.lld"
+        - "LLVM_PKG=llvm"
+      addons:
+        homebrew:
+          packages:
+            - llvm@7
+          update: true
 
-  allow_failures:
     - os: osx
-      name: "Mac OSX XCode latest"
+      osx_image: xcode10.1
+      name: "Mac OSX LLVM 6"
       env:
         - "C_COMPILER=clang"
         - "CXX_COMPILER=clang++"
@@ -96,6 +103,12 @@ matrix:
         - "OBJCOPY=llvm-objcopy"
         - "LINKER=lld"
         - "LLD=ld.lld"
+        - "LLVM_PKG=llvm@6"
+      addons:
+        homebrew:
+          packages:
+            - llvm@6
+          update: true
 
 script:
   - sh ci/script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: c
 
 dist: xenial
 
+branches:
+  only:
+    - master
+
 matrix:
   fast_finish: true
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ dist: xenial
 matrix:
   fast_finish: true
   include:
+
+    # ARM GCC (Linux)
+
     - os: linux
       name: "ARM GCC"
       env:
@@ -14,6 +17,8 @@ matrix:
         - "OBJCOPY=arm-none-eabi-objcopy"
         - "LINKER=arm-none-eabi-ld"
         - "LLD=arm-none-eabi-ld.bfd"
+
+    # Clang/LLVM + ARM GCC (Linux)
 
     - os: linux
       name: "Clang 6.0"
@@ -68,6 +73,29 @@ matrix:
             - clang-8
             - llvm-8
             - lld-8
+
+    # Clang/LLVM (macOS)
+
+    - os: osx
+      name: "Mac OSX XCode latest"
+      env:
+        - "C_COMPILER=clang"
+        - "CXX_COMPILER=clang++"
+        - "SIZE=llvm-size"
+        - "OBJCOPY=llvm-objcopy"
+        - "LINKER=lld"
+        - "LLD=ld.lld"
+
+  allow_failures:
+    - os: osx
+      name: "Mac OSX XCode latest"
+      env:
+        - "C_COMPILER=clang"
+        - "CXX_COMPILER=clang++"
+        - "SIZE=llvm-size"
+        - "OBJCOPY=llvm-objcopy"
+        - "LINKER=lld"
+        - "LLD=ld.lld"
 
 script:
   - sh ci/script.sh

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -3,13 +3,15 @@
 set -ex
 
 set_clang() {
-    # Make package installation path preceed Travis installed packages in /usr/local/bin
-    export PATH=/usr/bin:$PATH
-    sudo update-alternatives --install /usr/bin/clang clang /usr/bin/${C_COMPILER} 1000 --slave /usr/bin/clang++ clang++ /usr/bin/${CXX_COMPILER}
-    sudo update-alternatives --install /usr/bin/llvm-size llvm-size /usr/bin/${SIZE} 1000
-    sudo update-alternatives --install /usr/bin/llvm-objcopy llvm-objcopy /usr/bin/${OBJCOPY} 1000
-    sudo update-alternatives --install /usr/bin/lld lld /usr/bin/${LINKER} 1000
-    sudo update-alternatives --install /usr/bin/ld.lld ld.lld /usr/bin/${LLD} 1000
+    if [ ${TRAVIS_OS_NAME} = "linux" ]; then
+        # Make package installation path preceed Travis installed packages in /usr/local/bin
+        export PATH=/usr/bin:$PATH
+        sudo update-alternatives --install /usr/bin/clang clang /usr/bin/${C_COMPILER} 1000 --slave /usr/bin/clang++ clang++ /usr/bin/${CXX_COMPILER}
+        sudo update-alternatives --install /usr/bin/llvm-size llvm-size /usr/bin/${SIZE} 1000
+        sudo update-alternatives --install /usr/bin/llvm-objcopy llvm-objcopy /usr/bin/${OBJCOPY} 1000
+        sudo update-alternatives --install /usr/bin/lld lld /usr/bin/${LINKER} 1000
+        sudo update-alternatives --install /usr/bin/ld.lld ld.lld /usr/bin/${LLD} 1000
+    fi
 
     clang --version
     llvm-size --version

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -11,13 +11,18 @@ set_clang() {
         sudo update-alternatives --install /usr/bin/llvm-objcopy llvm-objcopy /usr/bin/${OBJCOPY} 1000
         sudo update-alternatives --install /usr/bin/lld lld /usr/bin/${LINKER} 1000
         sudo update-alternatives --install /usr/bin/ld.lld ld.lld /usr/bin/${LLD} 1000
+    elif [ ${TRAVIS_OS_NAME} = "osx" ]; then
+        export PATH="/usr/local/opt/${LLVM_PKG}/bin:$PATH"
     fi
 
     clang --version
-    llvm-size --version
+    llvm-size --version || true
+    size --version
     # LLVM objcopy version 7 misses `--version` support
     llvm-objcopy -version || true
-    ld.lld --version
+    objcopy --version || true
+    gobjcopy --version || true
+    ld --version || true
 }
 
 if [ ! -z "${TRAVIS+set}" ]; then
@@ -36,7 +41,20 @@ fi
 
 # Download ARM GCC toolchain from the official site
 # wget https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2018q4/gcc-arm-none-eabi-8-2018-q4-major-linux.tar.bz2 -O gcc-arm-none-eabi.tar.bz2
-curl -k -L https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2018q4/gcc-arm-none-eabi-8-2018-q4-major-linux.tar.bz2 -o gcc-arm-none-eabi.tar.bz2
+case "${TRAVIS_OS_NAME}" in
+    linux)
+        ARM_GCC_URI="https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2018q4/gcc-arm-none-eabi-8-2018-q4-major-linux.tar.bz2"
+        ;;
+    osx)
+        ARM_GCC_URI="https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2018q4/gcc-arm-none-eabi-8-2018-q4-major-mac.tar.bz2"
+        ;;
+    *)
+        >&2 echo "Unknown OS"
+        exit 1
+        ;;
+esac
+
+curl -k -L ${ARM_GCC_URI} -o gcc-arm-none-eabi.tar.bz2
 # curl -k -L https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2018q4/gcc-arm-none-eabi-8-2018-q4-major-win32.zip -o gcc-arm-none-eabi.zip
 tar jxf gcc-arm-none-eabi.tar.bz2
 # unzip gcc-arm-none-eabi.zip


### PR DESCRIPTION
Add Travis CI configuration to build example projects on Mac OSX instances with LLVM 6 and 7 as required in #8.