### PR TITLE
Fix for link time optimization of static libraries on Linux

### DIFF
--- a/arm-gcc-toolchain.cmake
+++ b/arm-gcc-toolchain.cmake
@@ -26,6 +26,8 @@ endif()
 set(CMAKE_C_COMPILER ${TOOLCHAIN_PREFIX}gcc)
 set(CMAKE_ASM_COMPILER ${CMAKE_C_COMPILER})
 set(CMAKE_CXX_COMPILER ${TOOLCHAIN_PREFIX}g++)
+set(CMAKE_AR ${TOOLCHAIN_PREFIX}gcc-ar)
+set(CMAKE_RANLIB ${TOOLCHAIN_PREFIX}gcc-ranlib)
 
 # Default C compiler flags
 set(CMAKE_C_FLAGS_DEBUG_INIT "-g3 -Og -Wall -pedantic -DDEBUG")


### PR DESCRIPTION
Fixes missing `plugin needed to handle lto object` error on Linux/Ubuntu when linking static libraries. Otherwise, you get the following:
```
[build] /usr/local/bin/arm-none-eabi-ar: test.c.o: plugin needed to handle lto object
[build] /usr/local/bin/arm-none-eabi-ranlib: lib.a(test.c.o): plugin needed to handle lto object
```
which results in an eventual `undefined reference` error from `arm-none-eabi/bin/ld`

Been using this on Windows for a long time with no issues. This only happened when moving over to Ubuntu and manually installing the latest [Arm GNU Toolchain](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads) files (since ARM stopped supporting PPA :roll_eyes:)